### PR TITLE
feat: add basket reservation flow

### DIFF
--- a/frontend/src/pages/ReserveBasket.vue
+++ b/frontend/src/pages/ReserveBasket.vue
@@ -1,38 +1,115 @@
 <template>
-  <div>
-    <h1>Basket</h1>
-    <div v-for="item in cart" :key="item.productId">
-      {{ item.name }} x {{ item.count }} = {{ item.unitPrice * item.count }}
+  <div class="basket">
+    <h1>سبد رزرو</h1>
+
+    <table v-if="cart.length">
+      <thead>
+        <tr>
+          <th>کالا</th>
+          <th>تعداد</th>
+          <th>قیمت واحد</th>
+          <th>قیمت</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr v-for="item in cart" :key="item.productId">
+          <td>{{ item.name }}</td>
+          <td>{{ item.count }}</td>
+          <td>{{ item.unitPrice }}</td>
+          <td>{{ item.unitPrice * item.count }}</td>
+        </tr>
+      </tbody>
+    </table>
+
+    <div class="dates">
+      <label>
+        تاریخ شروع
+        <input type="date" v-model="startDate" />
+      </label>
+      <label>
+        تاریخ پایان
+        <input type="date" v-model="endDate" />
+      </label>
     </div>
-    <div>
-      Start: <input type="date" v-model="start" />
-      End: <input type="date" v-model="end" />
+
+    <div class="total">
+      جمع کل: {{ totalPrice }}
     </div>
-    <button @click="confirm">Confirm</button>
-    <p v-if="msg">{{ msg }}</p>
+
+    <button :disabled="!datesValid" @click="confirmReservation">تایید نهایی</button>
+    <p v-if="message">{{ message }}</p>
   </div>
 </template>
 
 <script setup>
-import { ref } from 'vue';
+import { ref, computed } from 'vue';
 import { useRouter } from 'vue-router';
 import { createReservation } from '../services/reservation';
 
 const cart = ref(JSON.parse(localStorage.getItem('cart') || '[]'));
-const start = ref('');
-const end = ref('');
-const msg = ref('');
+const startDate = ref('');
+const endDate = ref('');
+const message = ref('');
 const router = useRouter();
 
-async function confirm() {
+const datesValid = computed(() => {
+  return (
+    startDate.value &&
+    endDate.value &&
+    new Date(startDate.value) <= new Date(endDate.value)
+  );
+});
+
+const totalPrice = computed(() => calculateTotalPrice());
+
+function calculateTotalPrice() {
+  if (!datesValid.value) return 0;
+  const days = Math.max(
+    1,
+    Math.ceil(
+      (new Date(endDate.value) - new Date(startDate.value)) /
+        (1000 * 60 * 60 * 24)
+    )
+  );
+  return cart.value.reduce(
+    (sum, item) => sum + item.unitPrice * item.count * days,
+    0
+  );
+}
+
+async function confirmReservation() {
+  if (!datesValid.value) return;
   try {
     const token = localStorage.getItem('token');
-    await createReservation({ items: cart.value, startDate: start.value, endDate: end.value }, token);
+    await createReservation(
+      {
+        items: cart.value,
+        startDate: startDate.value,
+        endDate: endDate.value
+      },
+      token
+    );
     localStorage.removeItem('cart');
-    msg.value = 'Reserved!';
+    message.value = 'رزرو شما با موفقیت ثبت شد.';
     setTimeout(() => router.push('/'), 1000);
-  } catch (e) {
-    msg.value = 'Reservation failed';
+  } catch (err) {
+    message.value = 'ثبت رزرو با شکست مواجه شد.';
   }
 }
 </script>
+<style scoped>
+.basket {
+  max-width: 600px;
+  margin: 0 auto;
+}
+
+.dates {
+  display: flex;
+  gap: 1rem;
+  margin: 1rem 0;
+}
+
+.total {
+  margin-bottom: 1rem;
+}
+</style>


### PR DESCRIPTION
## Summary
- rebuild basket page with table layout and date pickers
- compute total cost based on rental duration and items
- call reservation API and disable confirm until dates valid

## Testing
- `cd frontend && npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ab206198508332bf0da223a64a5395