### PR TITLE
feat: enhance user panel and reservations

### DIFF
--- a/frontend/src/pages/Login.vue
+++ b/frontend/src/pages/Login.vue
@@ -38,6 +38,7 @@ async function submit() {
       const { data } = await login(identifier.value, password.value);
       localStorage.setItem('token', data.token);
       localStorage.setItem('role', 'user');
+      localStorage.setItem('user', JSON.stringify(data.user));
       router.push('/reserve');
     } else {
       const { data } = await loginAdmin(username.value, password.value);

--- a/frontend/src/pages/MyPanel.vue
+++ b/frontend/src/pages/MyPanel.vue
@@ -1,6 +1,13 @@
 <template>
   <div>
     <h1>My Panel</h1>
+
+    <section>
+      <h2>User Details</h2>
+      <p>Name: {{ user.firstName }}</p>
+      <p>My Code: {{ user.myCode }}</p>
+    </section>
+
     <section>
       <h2>Messages</h2>
       <ul>
@@ -9,27 +16,68 @@
         </li>
       </ul>
     </section>
+
     <section>
       <h2>My Reservations</h2>
-      <div v-for="r in reservations" :key="r.trackingCode">
-        {{ r.trackingCode }} - {{ r.totalPrice }}
-      </div>
+      <table v-if="reservations.length">
+        <thead>
+          <tr>
+            <th>Tracking Code</th>
+            <th>Start</th>
+            <th>End</th>
+            <th>Total Price</th>
+            <th>Late Hours</th>
+            <th>Final Price</th>
+            <th></th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr v-for="r in reservations" :key="r.trackingCode">
+            <td>{{ r.trackingCode }}</td>
+            <td>{{ new Date(r.startDate).toLocaleDateString() }}</td>
+            <td>{{ new Date(r.endDate).toLocaleDateString() }}</td>
+            <td>{{ r.totalPrice }}</td>
+            <td>{{ r.lateHours }}</td>
+            <td>{{ r.finalPrice }}</td>
+            <td>
+              <router-link :to="`/factor/${r.trackingCode}`">View Invoice</router-link>
+            </td>
+          </tr>
+        </tbody>
+      </table>
+      <p v-else>No reservations.</p>
+    </section>
+
+    <section>
+      <h2>Actions</h2>
+      <router-link to="/reserve">Reserve</router-link>
+      <button @click="logout">Logout</button>
     </section>
   </div>
 </template>
 
 <script setup>
 import { ref, onMounted } from 'vue';
+import { useRouter } from 'vue-router';
 import { getMyReservations } from '../services/reservation';
 import { getMessages } from '../services/message';
 
 const reservations = ref([]);
 const messages = ref([]);
+const user = ref(JSON.parse(localStorage.getItem('user') || '{}'));
+const router = useRouter();
+
+function logout() {
+  localStorage.removeItem('token');
+  localStorage.removeItem('role');
+  localStorage.removeItem('user');
+  router.push('/login');
+}
 
 onMounted(async () => {
   const token = localStorage.getItem('token');
-  const { data } = await getMyReservations(token);
-  reservations.value = data;
+  if (!token) return router.push('/login');
+  reservations.value = await getMyReservations(token);
   const { data: msg } = await getMessages(token);
   messages.value = msg;
 });

--- a/frontend/src/services/reservation.js
+++ b/frontend/src/services/reservation.js
@@ -6,8 +6,13 @@ export function createReservation(data, token) {
   });
 }
 
-export function getMyReservations(token) {
-  return api.get('/reservations/me', {
+export async function getMyReservations(token) {
+  const { data } = await api.get('/reservations/me', {
     headers: { Authorization: `Bearer ${token}` }
   });
+
+  return data.map(r => ({
+    ...r,
+    finalPrice: r.finalPrice ?? r.totalPrice + r.totalPrice * 0.1 * (r.lateHours || 0)
+  }));
 }


### PR DESCRIPTION
## Summary
- show user info, messages, and reservation table with invoice links on My Panel
- compute final reservation prices including late penalties
- persist user details on login for display in panel

## Testing
- `npm test --prefix frontend`
- `npm test --prefix backend`


------
https://chatgpt.com/codex/tasks/task_e_68ab2064e810833292081ec45cc0a1f6